### PR TITLE
(CI/CD): Update deploy workflow for renamed target

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -33,7 +33,7 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           personal_token: ${{ secrets.PAGES_TOKEN }}
-          external_repository: DaiYuzeng/yuzengdai.github.io
+          external_repository: DaiYuzeng/daiyuzeng.github.io
           publish_branch: main
           publish_dir: ./out
           user_name: "github-actions[bot]"


### PR DESCRIPTION
We updated the target repo since we made a mistake about the repo name, which doesn't match my GitHub username.

Previous target repository name: `yuzengdai.github.io` leads to the wrong site URL: `https://daiyuzeng.github.io/yuzengdai.github.io`